### PR TITLE
[Feature] Update docblock params

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,12 +101,32 @@
 				"phpAddProperty.property.docblock.stopToImport": {
 					"type": "boolean",
 					"default": false,
-					"description": "Specifies whether to stop after typing the type to refer to an external fully qualified name with an alias or importing"
+					"description": "Specifies whether to stop after typing the @var type to refer to an external fully qualified name with an alias or importing"
 				},
 				"phpAddProperty.property.types": {
 					"type": "boolean",
 					"default": false,
 					"markdownDescription": "Specifies whether to enable PHP 7.4+ typed properties [More info](https://wiki.php.net/rfc/typed_properties_v2)"
+				},
+				"phpAddProperty.constructor.docblock.enable": {
+					"type": "boolean",
+					"default": false,
+					"description": "Specifies whether to add/update the docblock to the constructor"
+				},
+				"phpAddProperty.constructor.docblock.withParameter": {
+					"type": "boolean",
+					"default": false,
+					"description": "Specifies whether to add the docblock @param type together with the constructor parameter type"
+				},
+				"phpAddProperty.constructor.docblock.stopToImport": {
+					"type": "boolean",
+					"default": false,
+					"description": "Specifies whether to stop after typing the @param type to refer to an external fully qualified name with an alias or importing"
+				},
+				"phpAddProperty.constructor.docblock.stopForDescription": {
+					"type": "boolean",
+					"default": true,
+					"description": "Specifies whether to stop after typing the @var type to add a description"
 				},
 				"phpAddProperty.constructor.visibility.choose": {
 					"type": "boolean",

--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -384,13 +384,17 @@ class AddProperty {
             this.tabStops.constructorParameterStop++;
         }
 
-        let constructorParamDocblockText = '';
+        let constructorParamDocblockText = `\${${docblockTypeStop}}`;
+
+        if (this.type) {
+            constructorParamDocblockText = `\${${docblockTypeStop}:${this.type} }`;
+        }
 
         if (this.config('phpAddProperty.constructor.docblock.stopToImport') === true) {
             constructorParamDocblockText += `\$${dockblockImportStop}`;
         }
             
-        constructorParamDocblockText += `\$${docblockTypeStop} \\$${this.name}`;
+        constructorParamDocblockText += `\\$${this.name}`;
 
         if (this.config('phpAddProperty.constructor.docblock.stopForDescription') === true) {
             constructorParamDocblockText += `\$${this.tabStops.constructorDocblockDescription}`;

--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -113,6 +113,13 @@ class AddProperty {
             snippet += this.indentText(this.getPropertyStatementText());
         }
 
+        if (this.config('phpAddProperty.constructor.docblock.enable') === true) {
+            snippet += this.indentText("/**\n")
+                + this.indentText(" * Constructor.\n")
+                + this.indentText(`${this.getConstructorParamDocblockText()}\n`)
+                + this.indentText(" */\n")
+        }
+
         const visibility = this.config('phpAddProperty.constructor.visibility.default');
         let constructorText = this.indentText(
             this.config('phpAddProperty.constructor.visibility.choose') === true

--- a/test/fixtures/existing/inputs/ConstructorDocblockUsingDocblock.php
+++ b/test/fixtures/existing/inputs/ConstructorDocblockUsingDocblock.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    /** @var string */
+    private $name;
+}

--- a/test/fixtures/existing/outputs/ConstructorDocblockUsingDocblock.php
+++ b/test/fixtures/existing/outputs/ConstructorDocblockUsingDocblock.php
@@ -5,13 +5,14 @@ namespace StarWars;
 
 class Jedi
 {
+    /** @var string */
     private $name;
 
     /**
      * Constructor.
-     * @param $name
+     * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }

--- a/test/fixtures/new/inputs/AddConstructorDocblock.php
+++ b/test/fixtures/new/inputs/AddConstructorDocblock.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    
+}

--- a/test/fixtures/new/inputs/UpdateConstructorDocblock.php
+++ b/test/fixtures/new/inputs/UpdateConstructorDocblock.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $rank;
+
+    /**
+     * @param $rank Rank
+     */
+    public function __construct($rank)
+    {
+        $this->rank = $rank;
+    }
+}

--- a/test/fixtures/new/outputs/AddConstructorDocblock.php
+++ b/test/fixtures/new/outputs/AddConstructorDocblock.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    /**
+     * Constructor.
+     * @param  $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/test/fixtures/new/outputs/UpdateConstructorDocblock.php
+++ b/test/fixtures/new/outputs/UpdateConstructorDocblock.php
@@ -11,7 +11,7 @@ class Jedi
 
     /**
      * @param $rank Rank
-     * @param  $name
+     * @param $name
      */
     public function __construct($rank, $name)
     {

--- a/test/fixtures/new/outputs/UpdateConstructorDocblock.php
+++ b/test/fixtures/new/outputs/UpdateConstructorDocblock.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $rank;
+
+    private $name;
+
+    /**
+     * @param $rank Rank
+     * @param  $name
+     */
+    public function __construct($rank, $name)
+    {
+        $this->rank = $rank;
+        $this->name = $name;
+    }
+}

--- a/test/suite/addExistingProperty.test.js
+++ b/test/suite/addExistingProperty.test.js
@@ -26,6 +26,11 @@ suite('Add Existing Property', function () {
     test('Should add an existing property using type from docblock', async () => {
         await runFixture('UseDocblock.php', new vscode.Position(8, 0));
     });
+
+    test('Should add a docblock with @param using type from property docblock', async () => {
+        await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
+        await runFixture('ConstructorDocblockUsingDocblock.php', new vscode.Position(8, 0));
+    });
 });
 
 async function runFixture(fileName, cursorPosition) {

--- a/test/suite/addExistingProperty.test.js
+++ b/test/suite/addExistingProperty.test.js
@@ -11,6 +11,10 @@ suite('Add Existing Property', function () {
         await resetDefaultSettings();
     });
 
+    teardown(async () => {
+        await resetDefaultSettings();
+    });
+
     test('Should add an existing property and constructor in an empty class', async () => {
         await runFixture('EmptyClass.php', new vscode.Position(7, 0));
     });

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -42,6 +42,16 @@ suite('Add Property', function () {
     test('Should work with tab indentation', async () => {
         await runFixture('TabIndentation.php');
     });
+
+    test('Should add a docblock with @param along with the constructor', async () => {
+        await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
+        await runFixture('AddConstructorDocblock.php');
+    });
+
+    test('Should update the docblock adding the new @param', async () => {
+        await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
+        await runFixture('UpdateConstructorDocblock.php');
+    });
 });
 
 async function runFixture(fileName) {

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -11,6 +11,10 @@ suite('Add Property', function () {
         await resetDefaultSettings();
     });
 
+    teardown(async () => {
+        await resetDefaultSettings();
+    });
+
     test('Should insert property and constructor in an empty class', async () => {
         await runFixture('EmptyClass.php');
     });

--- a/test/suite/customization.test.js
+++ b/test/suite/customization.test.js
@@ -11,6 +11,10 @@ suite('Customizations', function () {
         await resetDefaultSettings();
     });
 
+    teardown(async () => {
+        await resetDefaultSettings();
+    });
+
     test('Should use the specified property default visibility', async () => {
         await vscode.workspace.getConfiguration('phpAddProperty').update('property.visibility.default', 'public', true);
         await runFixture('PropertyDefaultVisibility.php');


### PR DESCRIPTION
Closes #8 

This pull request adds a new option to enable the constructor docblock, adding properties will add/update the docblock with the new `@param` lines.