### PR TITLE
[Bugfix] Add a property to an empty constructor

### DIFF
--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -226,12 +226,13 @@ class AddProperty {
         }
 
         // Add property to constructor parameters
+        const constructorParameterLastLine = this.constructorLastParameterLine || this.constructorParametersCloseLine;
         const constructorLastParameterText = this.escapeForSnippet(
-            this.activeEditor().document.getText(this.constructorLastParameterLine.range)
+            this.activeEditor().document.getText(constructorParameterLastLine.range)
         );
 
-        let position = this.constructorLastParameterLine.range.end.character;
-        if (this.constructorLastParameterLine.lineNumber === this.constructorParametersCloseLine.lineNumber) {
+        let position = constructorParameterLastLine.range.end.character;
+        if (constructorParameterLastLine.lineNumber === this.constructorParametersCloseLine.lineNumber) {
             const match = /\)(?!\))/.exec(constructorLastParameterText);
             if (match) {
                 position = match.index - 1;
@@ -242,16 +243,16 @@ class AddProperty {
         position++;
 
         const newParameterText = this.getParameterText();
-        let newParameterWrapper = ',';
+        let newParameterWrapper = this.constructorLastParameterLine ? ',' : '';
         if (this.isMultiLineConstructor) {
             newParameterWrapper += "\n" + this.indentText(
                 newParameterText,
                 this.calculateIndentationLevel(
-                    this.getLineFirstNonIndentationCharacterIndex(this.constructorLastParameterLine)
+                    this.getLineFirstNonIndentationCharacterIndex(constructorParameterLastLine)
                 )
             );
         } else {
-            newParameterWrapper += ` ${newParameterText}`;
+            newParameterWrapper += (this.constructorLastParameterLine ? ' ' : '') + newParameterText;
         }
 
         const output = [

--- a/test/fixtures/existing/inputs/EmptyConstructor.php
+++ b/test/fixtures/existing/inputs/EmptyConstructor.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    public function __construct()
+    {
+    }
+}

--- a/test/fixtures/existing/outputs/EmptyConstructor.php
+++ b/test/fixtures/existing/outputs/EmptyConstructor.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/test/fixtures/new/inputs/EmptyConstructor.php
+++ b/test/fixtures/new/inputs/EmptyConstructor.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    public function __construct()
+    {
+    }
+}

--- a/test/fixtures/new/outputs/EmptyConstructor.php
+++ b/test/fixtures/new/outputs/EmptyConstructor.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/test/suite/addExistingProperty.test.js
+++ b/test/suite/addExistingProperty.test.js
@@ -19,6 +19,10 @@ suite('Add Existing Property', function () {
         await runFixture('EmptyClass.php', new vscode.Position(7, 0));
     });
 
+    test('Should add an existing property to an empty constructor', async () => {
+        await runFixture('EmptyConstructor.php', new vscode.Position(7, 0));
+    });
+
     test('Should add an existing property to an existing constructor', async () => {
         await runFixture('ExistingConstructor.php', new vscode.Position(9, 0));
     });

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -19,6 +19,10 @@ suite('Add Property', function () {
         await runFixture('EmptyClass.php');
     });
 
+    test('Should insert a new property and add it to an empty constructor', async () => {
+        await runFixture('EmptyConstructor.php');
+    });
+
     test('Should insert a new property and add it to an existing constructor', async () => {
         await runFixture('ExistingConstructor.php');
     });

--- a/test/suite/utils.js
+++ b/test/suite/utils.js
@@ -1,6 +1,6 @@
 const vscode = require('vscode');
 
-const waitToAssertInSeconds = 5;
+const waitToAssertInSeconds = 15;
 
 exports.waitToAssertInSeconds = waitToAssertInSeconds;
 


### PR DESCRIPTION
This pull request fixes an issue where the property won't be added if the constructor exists but is empty.