### PR TITLE
[Bugfix] Stop parsing document after a second open bracket

### DIFF
--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -23,7 +23,7 @@ class AddProperty {
             return;
         }
 
-        if (! /function __construct/gm.test(document.getText())) {
+        if (!this.constructorStartLine) {
             this.insertConstructor();
         } else {
             this.insertProperty();
@@ -588,6 +588,14 @@ class AddProperty {
                 }
 
                 this.lastPropertyLine = line;
+            }
+
+            const lineIsOpenBracketAfterClass = this.classLine
+                && this.classLine.lineNumber != line.lineNumber
+                && /^{/.test(this.getLineTextFromFirstNonIndentationCharacter(line));
+
+            if (lineIsOpenBracketAfterClass) {
+                break;
             }
 
             if (/function __construct/.test(textLine)) {

--- a/test/fixtures/new/inputs/ClassKeyword.php
+++ b/test/fixtures/new/inputs/ClassKeyword.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Blah;
+
+class TraitUsageResolver
+{
+    /**
+     * @var string
+     */
+    private $prop1;
+
+    public function foo()
+    {
+        return new class {
+            public function __construct()
+            {
+            }
+        };
+    }
+}

--- a/test/fixtures/new/outputs/ClassKeyword.php
+++ b/test/fixtures/new/outputs/ClassKeyword.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Blah;
+
+class TraitUsageResolver
+{
+    /**
+     * @var string
+     */
+    private $prop1;
+
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function foo()
+    {
+        return new class {
+            public function __construct()
+            {
+            }
+        };
+    }
+}

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -47,6 +47,10 @@ suite('Add Property', function () {
         await runFixture('TabIndentation.php');
     });
 
+    test('Should work when the class contains extra "class" keywords', async () => {
+        await runFixture('ClassKeyword.php');
+    });
+
     test('Should add a docblock with @param along with the constructor', async () => {
         await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
         await runFixture('AddConstructorDocblock.php');


### PR DESCRIPTION
Fixes #13 

This pull request fixes issues with extra "class" keywords in the class body.