### PR TITLE
[Feature] Support multiple classes

### DIFF
--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -462,7 +462,7 @@ class AddProperty {
     }
 
     isClassLine(textLine) {
-        return /^(?:(?:final|abstract)\s+)?class\s+\w+/.test(textLine);
+        return /(?:^(?:(?:final|abstract)\s+)?class\s+\w+)|(new\s+class)/.test(textLine);
     }
 
     replaceWithSnippet(text, range) {

--- a/src/AddProperty.js
+++ b/src/AddProperty.js
@@ -590,11 +590,11 @@ class AddProperty {
                 this.lastPropertyLine = line;
             }
 
-            const lineIsOpenBracketAfterClass = this.classLine
+            const lineIsBracketAfterClass = this.classLine
                 && this.classLine.lineNumber != line.lineNumber
-                && /^{/.test(this.getLineTextFromFirstNonIndentationCharacter(line));
+                && /^{|}/.test(this.getLineTextFromFirstNonIndentationCharacter(line));
 
-            if (lineIsOpenBracketAfterClass) {
+            if (lineIsBracketAfterClass) {
                 break;
             }
 

--- a/test/fixtures/new/inputs/AnonymousClass.php
+++ b/test/fixtures/new/inputs/AnonymousClass.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    public function stealth()
+    {
+        return new class {
+            
+        };
+    }
+}

--- a/test/fixtures/new/inputs/MultipleClasses.php
+++ b/test/fixtures/new/inputs/MultipleClasses.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    
+}
+
+class Sith
+{
+
+}

--- a/test/fixtures/new/inputs/MultipleClassesCursorInFirst.php
+++ b/test/fixtures/new/inputs/MultipleClassesCursorInFirst.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    
+}
+
+class Sith
+{
+
+}

--- a/test/fixtures/new/inputs/MultipleClassesCursorInLast.php
+++ b/test/fixtures/new/inputs/MultipleClassesCursorInLast.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    
+}
+
+class Sith
+{
+
+}

--- a/test/fixtures/new/outputs/AnonymousClass.php
+++ b/test/fixtures/new/outputs/AnonymousClass.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    public function stealth()
+    {
+        return new class {
+            private $name;
+
+            public function __construct($name)
+            {
+                $this->name = $name;
+            }
+        };
+    }
+}

--- a/test/fixtures/new/outputs/MultipleClasses.php
+++ b/test/fixtures/new/outputs/MultipleClasses.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}
+
+class Sith
+{
+
+}

--- a/test/fixtures/new/outputs/MultipleClassesCursorInFirst.php
+++ b/test/fixtures/new/outputs/MultipleClassesCursorInFirst.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}
+
+class Sith
+{
+
+}

--- a/test/fixtures/new/outputs/MultipleClassesCursorInLast.php
+++ b/test/fixtures/new/outputs/MultipleClassesCursorInLast.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace StarWars;
+
+class Jedi
+{
+    
+}
+
+class Sith
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -62,6 +62,10 @@ suite('Add Property', function () {
     test('Should insert property in the last class if the cursor is placed there', async () => {
         await runFixture('MultipleClassesCursorInLast.php', new vscode.Position(13, 0));
     });
+
+    test('Should insert property in an anonymous class', async () => {
+        await runFixture('AnonymousClass.php', new vscode.Position(11, 0));
+    });
     
     test('Should add a docblock with @param along with the constructor', async () => {
         await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -54,7 +54,15 @@ suite('Add Property', function () {
     test('Should insert property in the first class if the file contains multiple', async () => {
         await runFixture('MultipleClasses.php');
     });
+    
+    test('Should insert property in the first class if the cursor is placed there', async () => {
+        await runFixture('MultipleClassesCursorInFirst.php', new vscode.Position(8, 0));
+    });
 
+    test('Should insert property in the last class if the cursor is placed there', async () => {
+        await runFixture('MultipleClassesCursorInLast.php', new vscode.Position(13, 0));
+    });
+    
     test('Should add a docblock with @param along with the constructor', async () => {
         await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
         await runFixture('AddConstructorDocblock.php');
@@ -66,7 +74,7 @@ suite('Add Property', function () {
     });
 });
 
-async function runFixture(fileName) {
+async function runFixture(fileName, cursorPosition) {
     vscode.window.showInputBox = function () {
         return 'name';
     };
@@ -76,6 +84,10 @@ async function runFixture(fileName) {
     );
     const document = await vscode.workspace.openTextDocument(uri);
     await vscode.window.showTextDocument(document);
+
+    if (cursorPosition) {
+        vscode.window.activeTextEditor.selections = [new vscode.Selection(cursorPosition, cursorPosition)];
+    }
 
     await vscode.commands.executeCommand('phpAddProperty.add');
 

--- a/test/suite/addProperty.test.js
+++ b/test/suite/addProperty.test.js
@@ -51,6 +51,10 @@ suite('Add Property', function () {
         await runFixture('ClassKeyword.php');
     });
 
+    test('Should insert property in the first class if the file contains multiple', async () => {
+        await runFixture('MultipleClasses.php');
+    });
+
     test('Should add a docblock with @param along with the constructor', async () => {
         await vscode.workspace.getConfiguration('phpAddProperty').update('constructor.docblock.enable', true, true);
         await runFixture('AddConstructorDocblock.php');


### PR DESCRIPTION
This pull request adds support for inserting properties in multiple classes (including anonymous classes) in the same file. By default the property will be added to the first class found. This can be changed by placing the cursor inside the desired class.

It also fixes an issue with indentation where it will not respect the file indentation.